### PR TITLE
Optionally change "other" DB name if set at all

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,7 @@ DATABASES = {
     'default': dj_database_url.config(),
 }
 DATABASES['other'] = copy.deepcopy(DATABASES['default'])
-DATABASES['other']['NAME'] += '_other'
+if 'NAME' in DATABASES['other']:
+    DATABASES['other']['NAME'] += '_other'
 
 DATABASES = pgconnection.configure(DATABASES)


### PR DESCRIPTION
Some processes, such as building the documentation, doesn't require a full setup, such as a running database. Hence those builds tend to run without the DATABASE_URL environment variable even set. But `settings.py` assumes it is, as it copies the DB and modifies it's name slightly, which breaks the documentation builds.

Replicated locally by making sure `DATABASE_URL` was unset  and then run `poetry run make docs` and got the following exception:
```python
...
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/tomage/src/django-pgtrigger/settings.py", line 23, in <module>
    DATABASES['other']['NAME'] += '_other'
KeyError: 'NAME'
```

Here's a screen-shot from readthedocs.com build system:

![image](https://user-images.githubusercontent.com/806206/108008497-545bd400-6fb5-11eb-8e73-f97cd1b20599.png)

I'm not convinced this ought be the way to go about fixing this, so I'm open to suggestions.

Type: bug (NOTE: Contemplating if this shouldn't be a "trivial", since it _is_ kinda trivial.. But it did _break_ the doc building... Thoughts on this @wesleykendall ? I see no/little reason really to bump minor version - does feel like this ought just be a patch, no?).