### PR TITLE
Throw errors on invalid trigger definitions.

### DIFF
--- a/pgtrigger/core.py
+++ b/pgtrigger/core.py
@@ -570,7 +570,7 @@ class Trigger:
                     EXECUTE PROCEDURE {pgid}();
             EXCEPTION
                 -- Ignore issues if the trigger already exists
-                WHEN others THEN null;
+                WHEN duplicate_object THEN null;
             END $$;
         '''
 


### PR DESCRIPTION
Previously triggers were installed with a broad try/except in order to ignore
errors when installing duplicate triggers. This caused invalid triggers to
not be installed with no errors thrown.

The code was updated to catch the specific exception for duplicate triggers
and allow other trigger errors to surface. A failing test case was
added.

Type: bug