### PR TITLE
Fix incorrect name in example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -471,7 +471,7 @@ row with the exact same values? Here's how:
 
     @pgtrigger.register(
         pgtrigger.Protect(
-            name='protect_deletes',
+            name='protect_redundant_updates',
             operation=pgtrigger.Delete,
             condition=pgtrigger.Condition(
                 'OLD.* IS NOT DISTINCT FROM NEW.*'


### PR DESCRIPTION
Looks like this name was incorrectly copied from the previous example.